### PR TITLE
Allow access by bookmarklets

### DIFF
--- a/src/webroot/index.php
+++ b/src/webroot/index.php
@@ -1,5 +1,8 @@
 <?php
 
+// Allows access from remote javascript, e.g. bookmarklets
+header("Access-Control-Allow-Origin: *");
+
 // Resources that help us do cool things.
 require_once dirname(dirname(__FILE__)).'/resources/global_resources.php';
 require_once dirname(__FILE__).'/resources/php/index_resources.php';


### PR DESCRIPTION
I'd like to use da.gd to shorten urls automatically in a bookmarklet, but the Access-Control-Allow-Origin header needs to be set to \* to allow this. Bookmarklet: https://gist.github.com/blha303/7602104
