### PR TITLE
Set maxlength attribute on suffixes for /shorten.

### DIFF
--- a/src/applications/shorten/shorten.php
+++ b/src/applications/shorten/shorten.php
@@ -228,7 +228,7 @@ final class DaGdShortenController extends DaGdBaseClass {
       $content = '***da.gd***
 <form method="POST" action="">
 Long URL: <input type="text" name="url" id="url" size="35" /><br />
-Optional custom suffix (truncated at 10 chars): <input type="text" name="shorturl" size="20" /><br />
+Optional custom suffix (truncated at 10 chars): <input type="text" name="shorturl" size="20" maxlength="10" /><br />
 <input type="submit" value="Shorten URL" /><br />
 [help](/help) | [open source](http://github.com/codeblock/dagd)';
       $markup = new DaGdMarkup($content);


### PR DESCRIPTION
This makes it so that you can only enter 10 characters (which it is truncated to), in most web browsers.